### PR TITLE
Feature/add output queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Then run the executable like this:
 
 1. Include the header in your source file: `#include "thpool.h"`
 2. Create a thread pool with number of threads you want: `threadpool thpool = thpool_init(4);`
-3. Add work to the pool: `thpool_add_work(thpool, (void*)function_p, (void*)arg_p);`
+3. Add work to the pool: `thpool_add_work(thpool, job_uuid, (void*)th_func_p, (void*)arg_p);`
+4. Get result from thread: `thpool_get_result(thpool, job_uuid, retry_count_max, retry_interval_ns, result_p);`
 
 The workers(threads) will start their work automatically as fast as there is new work
-in the pool. If you want to wait for all added work to be finished before continuing
+in the pool's input queue (`thpool_->queue_in`). The result obtained from executing the function pointer will be stored in pool's output queue ()`thpool_->queue_out`). If you want to wait for all added work to be finished before continuing
 you can use `thpool_wait(thpool);`. If you want to destroy the pool you can use
 `thpool_destroy(thpool);`.
 
@@ -48,8 +49,9 @@ For a deeper look into the documentation check in the [thpool.h](https://github.
 | Function example                | Description                                                         |
 |---------------------------------|---------------------------------------------------------------------|
 | ***thpool_init(4)***            | Will return a new threadpool with `4` threads.                        |
-| ***thpool_add_work(thpool, (void&#42;)function_p, (void&#42;)arg_p)*** | Will add new work to the pool. Work is simply a function. You can pass a single argument to the function if you wish. If not, `NULL` should be passed. |
+| ***thpool_add_work(thpool, (void&#42;)th_func_p, (void&#42;)arg_p)*** | Will add new work to the pool. Work is simply a function. You can pass a single argument to the function if you wish. If not, `NULL` should be passed. |
 | ***thpool_wait(thpool)***       | Will wait for all jobs (both in queue and currently running) to finish. |
+| ***thpool_get_result(thpool, int job_uuid, int retry_count_max, int retry_interval_ns, (int&#42;) result_p)*** | Attempts to retrieve a job result identified by job_uuid.  |
 | ***thpool_destroy(thpool)***    | This will destroy the threadpool. If jobs are currently being executed, then it will wait for them to finish. |
 | ***thpool_pause(thpool)***      | All threads in the threadpool will pause no matter if they are idle or executing work. |
 | ***thpool_resume(thpool)***      | If the threadpool is paused, then all threads will resume from where they were.   |

--- a/example.c
+++ b/example.c
@@ -9,47 +9,82 @@
  * decide which thread will run what. So it is not an error of the thread pool but rather
  * a decision of the OS.
  *
+ * CLI compile:
+ * gcc example.c thpool.c -D THPOOL_DEBUG -pthread -o example
  * */
 
 #include <stdio.h>
 #include <pthread.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 #include "thpool.h"
 
 int task(void *arg){
 
-	int result = (int)(intptr_t)arg  + 10;
+	int result = (int)(intptr_t)arg  + 100;
 
-	printf("Thread #%u: parm:%d, ret:%d\n",
+	printf("Thread #%u: uuid:%d, ret:%d\n",
 	       (int)pthread_self(), (int)(intptr_t)arg, result);
 
 	return result;
 }
 
+#define NUM_LOOPS 100
+#define NUM_TASKS 100
+
+void gen_random_numbers(int array[], int len, int min, int max){
+	int i;
+	for (i = 0; i < len; i++)
+		array[i] = rand() % (max - min + 1) + min;
+}
+
+void gen_numbers(int array[], int len){
+	int i;
+	for (i = 0; i < len; i++)
+		array[i] = i;
+}
 
 int main(){
+	int arr_uuid[NUM_TASKS];
+	int num_errs=0;
 
-	puts("Making threadpool with 4 threads");
-	threadpool thpool = thpool_init(4);
+	srand( time(NULL) );
 
-	puts("\nAdding 40 tasks to threadpool");
-	int i;
-	int result;
-	for (i=0; i<40; i++){
-		thpool_add_work(thpool, i, task, (void*)(uintptr_t)i);
-	};
+	gen_random_numbers(arr_uuid, NUM_TASKS, 1, NUM_TASKS);
+	// gen_numbers(arr_uuid, NUM_TASKS);
 
-	thpool_wait(thpool);
+	printf("Main Thread #%u\n", (int)pthread_self());
+	int j;
+	for (j=0; j<NUM_LOOPS; j++){
+		puts("Making threadpool with 4 threads");
+		threadpool thpool = thpool_init(4);
 
-	puts("\nRetreiving 40 task results");
-	for (i=0; i<40; i++){
-		thpool_get_result(thpool, i, &result);
-		printf("uuid:%d, result:%d\n", i, result);
-	};
+		puts("\nAdding tasks to threadpool");
+		int i;
+		int result;
+		for (i=0; i<NUM_TASKS; i++){
+			thpool_add_work(thpool, arr_uuid[i], task, (void*)(uintptr_t)arr_uuid[i]);
+		};
 
-	thpool_wait(thpool);
-	puts("\nKilling threadpool");
-	thpool_destroy(thpool);
+		// thpool_wait(thpool);
+
+		puts("\nRetreiving results from threadpool");
+		for (i=0; i<NUM_TASKS; i++){
+			thpool_get_result(thpool, arr_uuid[i], &result);
+			printf("main: success uuid:%d, result:%d\n", arr_uuid[i], result);
+			if (result != arr_uuid[i]+100)
+				num_errs++;
+		};
+
+		thpool_wait(thpool);
+		puts("\nKilling threadpool");
+		thpool_destroy(thpool);
+
+		printf("main: completed loop %d\n", j);
+	}
+	printf("main: num_errs = %d\n", num_errs);
 
 	return 0;
 }

--- a/example.c
+++ b/example.c
@@ -1,14 +1,14 @@
-/* 
+/*
  * WHAT THIS EXAMPLE DOES
- * 
- * We create a pool of 4 threads and then add 40 tasks to the pool(20 task1 
+ *
+ * We create a pool of 4 threads and then add 40 tasks to the pool(20 task1
  * functions and 20 task2 functions). task1 and task2 simply print which thread is running them.
- * 
- * As soon as we add the tasks to the pool, the threads will run them. It can happen that 
+ *
+ * As soon as we add the tasks to the pool, the threads will run them. It can happen that
  * you see a single thread running all the tasks (highly unlikely). It is up the OS to
  * decide which thread will run what. So it is not an error of the thread pool but rather
  * a decision of the OS.
- * 
+ *
  * */
 
 #include <stdio.h>
@@ -16,25 +16,40 @@
 #include <stdint.h>
 #include "thpool.h"
 
-void task(void *arg){
-	printf("Thread #%u working on %d\n", (int)pthread_self(), (int) arg);
+int task(void *arg){
+
+	int result = (int)(intptr_t)arg  + 10;
+
+	printf("Thread #%u: parm:%d, ret:%d\n",
+	       (int)pthread_self(), (int)(intptr_t)arg, result);
+
+	return result;
 }
 
 
 int main(){
-	
+
 	puts("Making threadpool with 4 threads");
 	threadpool thpool = thpool_init(4);
 
-	puts("Adding 40 tasks to threadpool");
+	puts("\nAdding 40 tasks to threadpool");
 	int i;
+	int result;
 	for (i=0; i<40; i++){
-		thpool_add_work(thpool, task, (void*)(uintptr_t)i);
+		thpool_add_work(thpool, i, task, (void*)(uintptr_t)i);
 	};
 
 	thpool_wait(thpool);
-	puts("Killing threadpool");
+
+	puts("\nRetreiving 40 task results");
+	for (i=0; i<40; i++){
+		thpool_get_result(thpool, i, &result);
+		printf("uuid:%d, result:%d\n", i, result);
+	};
+
+	thpool_wait(thpool);
+	puts("\nKilling threadpool");
 	thpool_destroy(thpool);
-	
+
 	return 0;
 }

--- a/example.c
+++ b/example.c
@@ -16,7 +16,6 @@
 #include <stdio.h>
 #include <pthread.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include "thpool.h"
@@ -84,8 +83,8 @@ int main(){
 			                        &result);
 			printf("main: received result %d for uuid %d with ret %d\n", result, arr_uuid[i], ret);
 			if (result != arr_uuid[i]+100){
-				if (ret == -1) num_timeouts++;
-				else           num_errs++;
+				if (result == -1) num_timeouts++;
+				if (ret == -1) num_errs++;
 			}
 		}
 

--- a/tests/src/api.c
+++ b/tests/src/api.c
@@ -18,10 +18,10 @@ int main(int argc, char *argv[]){
 
 	/* Test if we can get the current number of working threads */
 	thpool = thpool_init(10);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
 	sleep(1);
 	num = thpool_num_threads_working(thpool);
 	if (thpool_num_threads_working(thpool) != 4) {
@@ -31,8 +31,8 @@ int main(int argc, char *argv[]){
 
 	/* Test (same as above) */
 	thpool = thpool_init(5);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
-	thpool_add_work(thpool, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_2_secs, NULL);
 	sleep(1);
 	num = thpool_num_threads_working(thpool);
 	if (num != 2) {

--- a/tests/src/conc_increment.c
+++ b/tests/src/conc_increment.c
@@ -17,7 +17,7 @@ void increment() {
 
 
 int main(int argc, char *argv[]){
-	
+
 	char* p;
 	if (argc != 3){
 		puts("This testfile needs exactly two arguments");
@@ -27,12 +27,12 @@ int main(int argc, char *argv[]){
 	int num_threads = strtol(argv[2], &p, 10);
 
 	threadpool thpool = thpool_init(num_threads);
-	
+
 	int n;
 	for (n=0; n<num_jobs; n++){
-		thpool_add_work(thpool, (void*)increment, NULL);
+		thpool_add_work(thpool, n, (void*)increment, NULL);
 	}
-	
+
 	thpool_wait(thpool);
 
 	printf("%d\n", sum);

--- a/tests/src/nonzero_heap_stack.c
+++ b/tests/src/nonzero_heap_stack.c
@@ -46,11 +46,11 @@ int main(){
 	puts("Adding 20 tasks to threadpool");
 	int i;
 	for (i=0; i<20; i++){
-		thpool_add_work(thpool, (void*)task, NULL);
+		thpool_add_work(thpool, i, (void*)task, NULL);
 	};
 
 	puts("Killing threadpool");
 	thpool_destroy(thpool);
-	
+
 	return 0;
 }

--- a/tests/src/pause_resume.c
+++ b/tests/src/pause_resume.c
@@ -4,15 +4,15 @@
 #include <stdlib.h>
 #include "../../thpool.h"
 
-/* 
+/*
  * THIS TEST NEEDS TO BE TIMED TO BE MEANINGFULL
- * 
+ *
  * main:    sleep 3 secs   sleep 2 secs
- *                      
+ *
  * thpool:                 sleep 4 secs
- * 
+ *
  * Thus the program should take just a bit more than 7 seconds.
- * 
+ *
  * */
 
 void sleep_4_secs(){
@@ -30,20 +30,20 @@ int main(int argc, char *argv[]){
 	int num_threads = strtol(argv[1], &p, 10);
 
 	threadpool thpool = thpool_init(num_threads);
-	
+
 	thpool_pause(thpool);
-	
+
 	// Since pool is paused, threads should not start before main's sleep
-	thpool_add_work(thpool, (void*)sleep_4_secs, NULL);
-	thpool_add_work(thpool, (void*)sleep_4_secs, NULL);
-	
+	thpool_add_work(thpool, 0, (void*)sleep_4_secs, NULL);
+	thpool_add_work(thpool, 0, (void*)sleep_4_secs, NULL);
+
 	sleep(3);
-	
+
 	// Now we will start threads in no-parallel with main
 	thpool_resume(thpool);
 
 	sleep(2); // Give some time to threads to get the work
-	
+
 	thpool_destroy(thpool); // Wait for work to finish
 
 	return 0;

--- a/tests/src/wait.c
+++ b/tests/src/wait.c
@@ -10,9 +10,9 @@
  *                                 number of threads,
  *                                 wait for each thread separetely (1)?
  *                                 how long each thread should run
- * 
+ *
  * Each job is to simply sleep for given amount of seconds.
- * 
+ *
  * */
 
 
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]){
 
 	int n;
 	for (n=0; n<num_jobs; n++){
-		thpool_add_work(thpool, (void*)sleep_1, &sleep_per_thread);
+		thpool_add_work(thpool, n, (void*)sleep_1, &sleep_per_thread);
 		if (wait_each_job)
 			thpool_wait(thpool);
 	}

--- a/thpool.c
+++ b/thpool.c
@@ -575,35 +575,37 @@ static struct job* jobqueue_pull_by_uuid(jobqueue* jobqueue_p, int uuid){
 		curr_job_p = curr_job_p->prev;
 	}
 
-	switch(jobqueue_p->len){
+	if (curr_job_p){
+		switch (jobqueue_p->len){
 
-		case 0:  /* if no jobs in queue */
-			break;
+			case 0:  /* if no jobs in queue */
+				break;
 
-		case 1:  /* if one job in queue */
-			jobqueue_p->front = NULL;
-			jobqueue_p->rear  = NULL;
-			jobqueue_p->len = 0;
-			break;
+			case 1:  /* if one job in queue */
+				jobqueue_p->front = NULL;
+				jobqueue_p->rear  = NULL;
+				jobqueue_p->len = 0;
+				break;
 
-		default: /* if >1 jobs in queue */
-			if (!last_job_p) {
-				/* Current job at queue front */
-				jobqueue_p->front = curr_job_p->prev;
-			}
-			else if (!curr_job_p->prev){
-				/* Current job at queue rear */
-				jobqueue_p->rear = last_job_p;
-				last_job_p->prev = NULL;
-			}
-			else {
-				/* Current job somewhere in the middle */
-				last_job_p->prev = curr_job_p->prev;
-			}
+			default: /* if >1 jobs in queue */
+				if (!last_job_p) {
+					/* Current job at queue front */
+					jobqueue_p->front = curr_job_p->prev;
+				}
+				else if (!curr_job_p->prev){
+					/* Current job at queue rear */
+					jobqueue_p->rear = last_job_p;
+					last_job_p->prev = NULL;
+				}
+				else {
+					/* Current job somewhere in the middle */
+					last_job_p->prev = curr_job_p->prev;
+				}
 
-			jobqueue_p->len--;
-			/* more than one job in queue -> post it */
-			bsem_post(jobqueue_p->has_jobs);
+				jobqueue_p->len--;
+				/* more than one job in queue -> post it */
+				bsem_post(jobqueue_p->has_jobs);
+		}
 	}
 
 	pthread_mutex_unlock(&jobqueue_p->rwmutex);

--- a/thpool.c
+++ b/thpool.c
@@ -57,10 +57,12 @@ typedef struct bsem {
 
 
 /* Job */
+typedef	void (*function_p)(void* arg);       /* function pointer          */
+
 typedef struct job{
-	struct job*  prev;                   /* pointer to previous job   */
-	void   (*function)(void* arg);       /* function pointer          */
-	void*  arg;                          /* function's argument       */
+	struct job*  prev;           /* pointer to previous job   */
+	function_p   function;       /* function pointer          */
+	void*        arg;            /* function's argument       */
 } job;
 
 
@@ -188,7 +190,7 @@ struct thpool_* thpool_init(int num_threads){
 
 
 /* Add work to the thread pool */
-int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
+int thpool_add_work(thpool_* thpool_p, function_p func_p, void* arg_p){
 	job* newjob;
 
 	newjob=(struct job*)malloc(sizeof(struct job));
@@ -198,7 +200,7 @@ int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
 	}
 
 	/* add function and argument */
-	newjob->function=function_p;
+	newjob->function=func_p;
 	newjob->arg=arg_p;
 
 	/* add job to queue */
@@ -374,7 +376,7 @@ static void* thread_do(struct thread* thread_p){
 			pthread_mutex_unlock(&thpool_p->thcount_lock);
 
 			/* Read job from queue and execute it */
-			void (*func_buff)(void*);
+			function_p func_buff;
 			void*  arg_buff;
 			job* job_p = jobqueue_pull(&thpool_p->queue_in);
 			if (job_p) {

--- a/thpool.c
+++ b/thpool.c
@@ -57,8 +57,6 @@ typedef struct bsem {
 
 
 /* Job */
-typedef	void (*function_p)(void* arg);       /* function pointer          */
-
 typedef struct job{
 	struct job*  prev;           /* pointer to previous job   */
 	function_p   function;       /* function pointer          */

--- a/thpool.c
+++ b/thpool.c
@@ -40,7 +40,7 @@
 #define err(str)
 #endif
 
-//TODO: How deal with these when I have multiple thread pools, each one needing to be individually controlled????
+//TODO:(captured) How deal with these when I have multiple thread pools, each one needing to be individually controlled????
 //		Move into thpool struct???
 static volatile int threads_keepalive;
 static volatile int threads_on_hold;
@@ -48,13 +48,14 @@ static volatile int threads_on_hold;
 
 //TODO DUMPING GROUND
 //===================
-//TODO: Need to expand existing test harness with new result retrieval code.
-//TODO: Change all functions to return an error code or nothing??
+//TODO:(captured) Need to expand existing test harness with new result retrieval code.
+//TODO:(captured) Change all functions to return an error code or nothing??
 //		Pass all return values in as function parameters
 //		Should all lock()\unlock() calls have their ec checked\returned (as part of a general ec handling framework)?
-//TODO: Better solution for all the debug messages
-//TODO: add queue metrics
-//TODO: add queue size limit (or maybe just a warning that a threshold has been exceeded)
+//TODO:(captured) Better solution for all the debug messages
+//TODO:(captured) add queue metrics
+//TODO:(captured) add queue size limit (or maybe just a warning that a threshold has been exceeded)
+//TODO:(captured) Some\all structs need to move to .h file, so available to users of primary thpool apis.
 
 
 
@@ -358,7 +359,7 @@ int thpool_num_threads_working(thpool_* thpool_p){
  * @param id            id to be given to the thread
  * @return 0 on success, -1 otherwise.
  */
-//TODO: Change thread id to set internally
+//TODO: Change thread id to set internally???
 static int thread_init (thpool_* thpool_p, struct thread** thread_p, int id){
 
 	*thread_p = (struct thread*)malloc(sizeof(struct thread));
@@ -521,8 +522,8 @@ static void jobqueue_clear(jobqueue* jobqueue_p){
  */
 static void jobqueue_push(jobqueue* jobqueue_p, struct job* newjob){
 
-//TODO: How handle if newjob != NULL
-//		Would need returned ec from this func
+//TODO:(captured) How handle if newjob != NULL
+//		Would need returned ec from this func.  Change when changing all functions to return an ec.
 
 	// printf("          push: start: job(%p) to queue(%p) on thread #%u\n", newjob, jobqueue_p, (int)pthread_self());
 	pthread_mutex_lock(&jobqueue_p->rwmutex);

--- a/thpool.c
+++ b/thpool.c
@@ -89,7 +89,9 @@ typedef struct thpool_{
 	volatile int num_threads_working;    /* threads currently working */
 	pthread_mutex_t  thcount_lock;       /* used for thread count etc */
 	pthread_cond_t  threads_all_idle;    /* signal to thpool_wait     */
-	jobqueue  jobqueue;                  /* job queue                 */
+	// jobqueue  jobqueue;                  /* job queue                 */
+	jobqueue  queue_in;                  /* job queue for input       */
+	jobqueue  queue_out;                 /* job queue for output      */
 } thpool_;
 
 
@@ -144,8 +146,8 @@ struct thpool_* thpool_init(int num_threads){
 	thpool_p->num_threads_working = 0;
 
 	/* Initialise the job queue */
-	if (jobqueue_init(&thpool_p->jobqueue) == -1){
-		err("thpool_init(): Could not allocate memory for job queue\n");
+	if (jobqueue_init(&thpool_p->queue_in) == -1){
+		err("thpool_init(): Could not allocate memory for input job queue\n");
 		free(thpool_p);
 		return NULL;
 	}
@@ -154,7 +156,7 @@ struct thpool_* thpool_init(int num_threads){
 	thpool_p->threads = (struct thread**)malloc(num_threads * sizeof(struct thread *));
 	if (thpool_p->threads == NULL){
 		err("thpool_init(): Could not allocate memory for threads\n");
-		jobqueue_destroy(&thpool_p->jobqueue);
+		jobqueue_destroy(&thpool_p->queue_in);
 		free(thpool_p);
 		return NULL;
 	}
@@ -193,7 +195,7 @@ int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
 	newjob->arg=arg_p;
 
 	/* add job to queue */
-	jobqueue_push(&thpool_p->jobqueue, newjob);
+	jobqueue_push(&thpool_p->queue_in, newjob);
 
 	return 0;
 }
@@ -202,7 +204,7 @@ int thpool_add_work(thpool_* thpool_p, void (*function_p)(void*), void* arg_p){
 /* Wait until all jobs have finished */
 void thpool_wait(thpool_* thpool_p){
 	pthread_mutex_lock(&thpool_p->thcount_lock);
-	while (thpool_p->jobqueue.len || thpool_p->num_threads_working) {
+	while (thpool_p->queue_in.len || thpool_p->num_threads_working) {
 		pthread_cond_wait(&thpool_p->threads_all_idle, &thpool_p->thcount_lock);
 	}
 	pthread_mutex_unlock(&thpool_p->thcount_lock);
@@ -225,19 +227,19 @@ void thpool_destroy(thpool_* thpool_p){
 	double tpassed = 0.0;
 	time (&start);
 	while (tpassed < TIMEOUT && thpool_p->num_threads_alive){
-		bsem_post_all(thpool_p->jobqueue.has_jobs);
+		bsem_post_all(thpool_p->queue_in.has_jobs);
 		time (&end);
 		tpassed = difftime(end,start);
 	}
 
 	/* Poll remaining threads */
 	while (thpool_p->num_threads_alive){
-		bsem_post_all(thpool_p->jobqueue.has_jobs);
+		bsem_post_all(thpool_p->queue_in.has_jobs);
 		sleep(1);
 	}
 
 	/* Job queue cleanup */
-	jobqueue_destroy(&thpool_p->jobqueue);
+	jobqueue_destroy(&thpool_p->queue_in);
 	/* Deallocs */
 	int n;
 	for (n=0; n < threads_total; n++){
@@ -354,7 +356,7 @@ static void* thread_do(struct thread* thread_p){
 
 	while(threads_keepalive){
 
-		bsem_wait(thpool_p->jobqueue.has_jobs);
+		bsem_wait(thpool_p->queue_in.has_jobs);
 
 		if (threads_keepalive){
 
@@ -365,7 +367,7 @@ static void* thread_do(struct thread* thread_p){
 			/* Read job from queue and execute it */
 			void (*func_buff)(void*);
 			void*  arg_buff;
-			job* job_p = jobqueue_pull(&thpool_p->jobqueue);
+			job* job_p = jobqueue_pull(&thpool_p->queue_in);
 			if (job_p) {
 				func_buff = job_p->function;
 				arg_buff  = job_p->arg;

--- a/thpool.c
+++ b/thpool.c
@@ -409,6 +409,10 @@ static void* thread_do(struct thread* thread_p){
 	thpool_p->num_threads_alive += 1;
 	pthread_mutex_unlock(&thpool_p->thcount_lock);
 
+	struct timespec ts;
+	ts.tv_sec  = 0;
+	ts.tv_nsec = 1;
+
 	while(threads_keepalive){
 
 		bsem_wait(thpool_p->queue_in.has_jobs);
@@ -437,6 +441,7 @@ static void* thread_do(struct thread* thread_p){
 			}
 			pthread_mutex_unlock(&thpool_p->thcount_lock);
 
+			nanosleep(&ts, &ts);     /* Allow other threads CPU time */
 		}
 	}
 	pthread_mutex_lock(&thpool_p->thcount_lock);

--- a/thpool.c
+++ b/thpool.c
@@ -61,6 +61,7 @@ typedef struct job{
 	struct job*  prev;           /* pointer to previous job   */
 	function_p   function;       /* function pointer          */
 	void*        arg;            /* function's argument       */
+	int          result;         /* job result code           */
 } job;
 
 
@@ -378,10 +379,10 @@ static void* thread_do(struct thread* thread_p){
 			void*  arg_buff;
 			job* job_p = jobqueue_pull(&thpool_p->queue_in);
 			if (job_p) {
-				func_buff = job_p->function;
-				arg_buff  = job_p->arg;
-				func_buff(arg_buff);
-				free(job_p);
+				func_buff     = job_p->function;
+				arg_buff      = job_p->arg;
+				job_p->result = func_buff(arg_buff);
+				jobqueue_push(&thpool_p->queue_out, job_p);
 			}
 
 			pthread_mutex_lock(&thpool_p->thcount_lock);

--- a/thpool.h
+++ b/thpool.h
@@ -69,7 +69,13 @@ threadpool thpool_init(int num_threads);
  */
 int thpool_add_work(threadpool, int job_uuid, function_p func_p, void* arg_p);
 
-int thpool_get_result(threadpool, int job_uuid, int* result);
+
+//TODO: Finish docstring
+// @retry_count_max       max retries for job_uuid search
+// @retry_interval_ns     wait time between job_uuid searches in nsec
+// Return -1 if result NOT found
+int thpool_get_result(threadpool, int job_uuid, int retry_count_max, int retry_interval_ns, int* result);
+
 
 /**
  * @brief Wait for all queued jobs to finish

--- a/thpool.h
+++ b/thpool.h
@@ -16,7 +16,7 @@ extern "C" {
 
 typedef struct thpool_* threadpool;
 
-typedef	int (*function_p)(void* arg);       /* function pointer          */
+typedef	int (*th_func_p)(void* arg);       /* function pointer          */
 
 
 /**
@@ -40,11 +40,11 @@ threadpool thpool_init(int num_threads);
 
 
 /**
- * @brief Add work to the job queue
+ * @brief Add work to the pool's input job queue
  *
- * Takes an action and its argument and adds it to the threadpool's job queue.
- * If you want to add to work a function with more than one arguments then
- * a way to implement this is by passing a pointer to a structure.
+ * Takes an action and its argument and adds it to the threadpool's input job
+ * queue.  If you want to add to work a function with more than one arguments
+ * then a way to implement this is by passing a pointer to a structure.
  *
  * NOTICE: You have to cast both the function and argument to not get warnings.
  *
@@ -57,7 +57,7 @@ threadpool thpool_init(int num_threads);
  *    int main() {
  *       ..
  *       int a = 10;
- *       thpool_add_work(thpool, (void*)print_num, (void*)a);
+ *       thpool_add_work(thpool, job_uuid, (void*)print_num, (void*)a);
  *       ..
  *    }
  *
@@ -67,18 +67,48 @@ threadpool thpool_init(int num_threads);
  * @param  arg_p         pointer to an argument
  * @return 0 on success, -1 otherwise.
  */
-int thpool_add_work(threadpool, int job_uuid, function_p func_p, void* arg_p);
-
-
-//TODO: Finish docstring
-// @retry_count_max       max retries for job_uuid search
-// @retry_interval_ns     wait time between job_uuid searches in nsec
-// Return -1 if result NOT found
-int thpool_get_result(threadpool, int job_uuid, int retry_count_max, int retry_interval_ns, int* result);
+int thpool_add_work(threadpool, int job_uuid, th_func_p func_p, void* arg_p);
 
 
 /**
- * @brief Wait for all queued jobs to finish
+ * @brief Attempts to retrieve the result from the pool's output job queue
+ *
+ * Result is the return value from the passed in function pointer's execution.
+ * Each result is identified by a specific job_uuid.
+ *
+ * NOTICE: After thpool_add_work() is called, if this function is called too
+ * soon, or the rety values are not tuned correctly, the desired job_uuid
+ * may not be found.
+ *
+ * @example
+ *
+ *    void print_num(int num){
+ *       printf("%d\n", num);
+ *    }
+ *
+ *    int main() {
+ *       ..
+ *       int a = 10;
+ *       thpool_add_work(thpool, job_uuid, (void*)print_num, (void*)a);
+ *       ..
+ *       int res = 10;
+ *       int ret;
+ *       ret = thpool_add_work(thpool, job_uuid, 1000, 1000, &res);
+ *       ..
+ *    }
+ *
+ * @param  threadpool            threadpool to which the work will be added
+ * @param  job_uuid              unique job identifier to search for in queue_out
+ * @param  retry_count_max       max retries for job_uuid search
+ * @param  retry_interval_ns     wait time between job_uuid searches in nsec
+ * @param  result_p              returned result from function pointer execution (-1 if result NOT found)
+ * @return 0 on success, -1 otherwise.
+ */
+int thpool_get_result(threadpool, int job_uuid, int retry_count_max, int retry_interval_ns, int* result_p);
+
+
+/**
+ * @brief Wait for all queued input jobs to finish
  *
  * Will wait for all jobs - both queued and currently running to finish.
  * Once the queue is empty and all work has completed, the calling thread

--- a/thpool.h
+++ b/thpool.h
@@ -16,6 +16,8 @@ extern "C" {
 
 typedef struct thpool_* threadpool;
 
+typedef	void (*function_p)(void* arg);       /* function pointer          */
+
 
 /**
  * @brief  Initialize threadpool
@@ -60,11 +62,11 @@ threadpool thpool_init(int num_threads);
  *    }
  *
  * @param  threadpool    threadpool to which the work will be added
- * @param  function_p    pointer to function to add as work
+ * @param  func_p        pointer to function to add as work
  * @param  arg_p         pointer to an argument
  * @return 0 on success, -1 otherwise.
  */
-int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
+int thpool_add_work(threadpool, function_p func_p, void* arg_p);
 
 
 /**

--- a/thpool.h
+++ b/thpool.h
@@ -16,7 +16,7 @@ extern "C" {
 
 typedef struct thpool_* threadpool;
 
-typedef	void (*function_p)(void* arg);       /* function pointer          */
+typedef	int (*function_p)(void* arg);       /* function pointer          */
 
 
 /**
@@ -66,8 +66,9 @@ threadpool thpool_init(int num_threads);
  * @param  arg_p         pointer to an argument
  * @return 0 on success, -1 otherwise.
  */
-int thpool_add_work(threadpool, function_p func_p, void* arg_p);
+int thpool_add_work(threadpool, int uuid, function_p func_p, void* arg_p);
 
+int thpool_get_result(threadpool, int uuid, int* result);
 
 /**
  * @brief Wait for all queued jobs to finish

--- a/thpool.h
+++ b/thpool.h
@@ -62,13 +62,14 @@ threadpool thpool_init(int num_threads);
  *    }
  *
  * @param  threadpool    threadpool to which the work will be added
+ * @param  job_uuid      unique job identifier
  * @param  func_p        pointer to function to add as work
  * @param  arg_p         pointer to an argument
  * @return 0 on success, -1 otherwise.
  */
-int thpool_add_work(threadpool, int uuid, function_p func_p, void* arg_p);
+int thpool_add_work(threadpool, int job_uuid, function_p func_p, void* arg_p);
 
-int thpool_get_result(threadpool, int uuid, int* result);
+int thpool_get_result(threadpool, int job_uuid, int* result);
 
 /**
  * @brief Wait for all queued jobs to finish


### PR DESCRIPTION
This merge request represents the initial evaluation of the original C-Thread-Pool project.  Done for jira ticket # FOSS-527.

Main work done was to see if adding an output queue would be reasonably possible.  It was.  This is necessary so that the main thread can asynchronous make job submissions and then, later, asynchronously go query for the corresponding result, currently identified by a job_uuid.  

The ./example.c file grew unintentionally large.  This'll be fixed in future work.

The changes to the thread function pointer may also need to be revisited.

Most other TODOs have also been captured in additional jira tickets.