### PR TITLE
Feature/foss 530 refactor globals pool controls

### DIFF
--- a/thpool.c
+++ b/thpool.c
@@ -114,7 +114,8 @@ typedef struct thpool_{
 	pthread_mutex_t  thcount_lock;       /* used for thread count etc */
 	pthread_cond_t  threads_all_idle;    /* signal to thpool_wait     */
 
-	volatile int threads_keepalive;      /* All threads live\die flag */
+	volatile int threads_keepalive;      /* live\die status flag      */
+	volatile int threads_on_hold;        /* run\pause status flag     */
 	pthread_mutex_t  alive_lock;         /* used for thpool run state */
 
 	jobqueue  queue_in;                  /* queue for pending jobs    */
@@ -171,6 +172,7 @@ struct thpool_* thpool_init(int num_threads){
 	}
 	thpool_p->num_threads_alive   = 0;
 	thpool_p->num_threads_working = 0;
+	thpool_p->threads_on_hold     = 0;
 	thpool_p->threads_keepalive   = 1;
 
 	/* Initialise the job queue */
@@ -367,6 +369,7 @@ void thpool_pause(thpool_* thpool_p) {
 	for (n=0; n < thpool_num_threads_alive(thpool_p); n++){
 		pthread_kill(thpool_p->threads[n]->pthread, SIGUSR1);
 	}
+	thpool_p->threads_on_hold = 1;
 }
 
 
@@ -376,6 +379,7 @@ void thpool_resume(thpool_* thpool_p) {
 	for (n=0; n < thpool_num_threads_alive(thpool_p); n++){
 		pthread_kill(thpool_p->threads[n]->pthread, SIGUSR2);
 	}
+	thpool_p->threads_on_hold = 0;
 }
 
 

--- a/thpool.h
+++ b/thpool.h
@@ -202,7 +202,30 @@ void thpool_destroy(threadpool);
 
 
 /**
- * @brief Show currently working threads
+ * @brief Show number of currently active threads
+ *
+ * This is total total number of active thread in the pool, working
+ * and idle.  Should always be the same.
+ * Function created to ensure thread-safe access of value.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    printf("Working threads: %d\n", thpool_num_threads_alive(thpool1));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       number of threads alive in pool
+ */
+int thpool_num_threads_alive(threadpool);
+
+
+/**
+ * @brief Show number of currently working threads
  *
  * Working threads are the threads that are performing work (not idle).
  *

--- a/thpool.h
+++ b/thpool.h
@@ -240,6 +240,24 @@ int thpool_num_threads_working(threadpool);
  */
 int thpool_queue_out_len(threadpool);
 
+/**
+ * @brief Show current state of thpool "keepalive" flag.
+ *
+ * @example
+ * int main() {
+ *    threadpool thpool1 = thpool_init(2);
+ *    threadpool thpool2 = thpool_init(2);
+ *    ..
+ *    printf("Queue out length: %d\n", thpool_alive_state(thpool1));
+ *    ..
+ *    return 0;
+ * }
+ *
+ * @param threadpool     the threadpool of interest
+ * @return integer       thpool's "keepalive" flag state.
+ *                       1 - keep all threads alive, 0 - kill all threads
+ */
+int thpool_alive_state(threadpool);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Refactored some global thread pool controls to within the primary threadpool c-struct.  Done so that each thread pool could be controlled (ie - killed\paused) individually.  The "pause" mechanism was adjusted to just use the "signaling" mechanism within signal.h.  The "kill" switch was given it's own mutex.

Also found that the "pthread_..._destroy()" functions were not being used anywhere in the thread pool project.  My reading of the pthread documentation indicates that these are required.  Added where needed.

Added some "getter"'s to the thread pool api interface to ensure thread-safe access of certain counters being written to and read from multiple threads. 